### PR TITLE
Added reference to staging API

### DIFF
--- a/bigmoney.js
+++ b/bigmoney.js
@@ -1,6 +1,8 @@
 import Vue from "vue";
 
 var localURL = "http://localhost:8000/";
+var stagingURL = "bigmoney-staging.bhga6ezash.us-west-2.elasticbeanstalk.com";
+var endpoint = localURL;
 var donationsEndpoint = "api/donations/";
 var contributorsEndpoint = "api/contributors/";
 var donationsQuery = {
@@ -23,7 +25,7 @@ Vue.filter('currency',  function(value) {
   return '$' + formatted;
 });
 
-$.getJSON(localURL+contributorsEndpoint, contributorsQuery)
+$.getJSON(endpoint+contributorsEndpoint, contributorsQuery)
   .done((data) => {
     new Vue({
       el: '#contributors-list',


### PR DESCRIPTION
CORS issue is resolved with staging API.  Staging API did not have correct CORS header before, so couldn't make XHR requests to it.

Script now refers to the variable 'endpoint' which can be set to the local or staging URL depending on what's useful for development. 